### PR TITLE
Improves ascii mutation to support delimiters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,6 +783,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
+ "nom",
  "print_bytes",
  "rand",
  "rand_chacha",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ regex = "1.7.3"
 strum = "0.24"
 strum_macros = "0.24"
 snowflake = "1.2"
+nom = "7.1.3"
 
 
 [target.'cfg(unix)'.dependencies]

--- a/src/mutations.rs
+++ b/src/mutations.rs
@@ -1041,12 +1041,14 @@ mod ascii;
 
 pub fn ascii_bad(_rng: &mut dyn RngCore, _data: Option<&Vec<u8>>) -> (Option<Vec<u8>>, isize) {
     if let Some(data) = _data {
-        let mut cs = ascii::Ascii::lex(data);
-        if cs.first_block_has_text() {
-            cs.mutate(_rng);
-            return (Some(cs.unlex()), rand_delta_up(_rng));
-        } else {
-            return (Some(data.clone()), -1);
+        match ascii::Ascii::parse(data) {
+            Ok(mut cs) => {
+                cs.mutate(_rng);
+                return (Some(cs.unlex()), rand_delta_up(_rng));
+            }
+            Err(_) => {
+                return (Some(data.clone()), -1);
+            }
         }
     }
     (None, 0)

--- a/src/mutations/ascii.rs
+++ b/src/mutations/ascii.rs
@@ -37,8 +37,7 @@ fn random_badness(_rng: &mut dyn RngCore) -> Vec<u8> {
 }
 
 fn mutate_text_data(_rng: &mut dyn RngCore, data: &mut Vec<u8>) {
-    assert!(data.len() > 0);
-    let idx = _rng.gen_range(0..data.len());
+    let idx = _rng.gen_range(0..=data.len());
     match _rng.gen_range(0..=2) {
         0 => {
             // insert badness

--- a/src/mutations/ascii.rs
+++ b/src/mutations/ascii.rs
@@ -1,3 +1,11 @@
+use nom::branch::alt;
+use nom::bytes::complete::{is_not, tag, take, take_while};
+use nom::character::complete::char;
+use nom::combinator::{consumed, verify};
+use nom::multi::{fold_many0, many0};
+use nom::sequence::delimited;
+use nom::sequence::preceded;
+use nom::{IResult, Parser};
 use rand::{seq::SliceRandom, Rng, RngCore};
 
 lazy_static! {
@@ -68,120 +76,205 @@ fn mutate_text_data(_rng: &mut dyn RngCore, data: &mut Vec<u8>) {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) enum Delimiter {
-    SingleQuote,
-    DoubleQuote,
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub struct Delimited {
+    pub delimitor: u8,
+    pub data: Vec<u8>,
 }
 
-impl Delimiter {
-    pub(crate) fn as_u8(&self) -> u8 {
+impl Delimited {
+    fn delimitor(c: char, data: &[u8]) -> Self {
+        Self {
+            delimitor: c as u8,
+            data: data.to_owned(),
+        }
+    }
+
+    fn unlex(self, v: &mut Vec<u8>) {
+        v.push(self.delimitor);
+        v.extend(self.data.into_iter());
+        v.push(self.delimitor);
+    }
+}
+
+/// parse a string delimited by quotes
+fn parse_quoted_string(delim: char) -> impl FnMut(&[u8]) -> IResult<&[u8], Delimited> {
+    move |input: &[u8]| {
+        // parse until a terminating quote character, ignoring escaped quotes
+        let build_string = consumed(many0(alt((
+            // parse until a delim or an escape char
+            verify(
+                take_while(|c: u8| c != '\\' as u8 && c != delim as u8),
+                |s: &[u8]| !s.is_empty(),
+            ),
+            // eat escaped literals
+            preceded(char('\\'), take(1usize)),
+        ))))
+        .map(|(consumed, _)| consumed);
+
+        // parse the entire quote-delimited string
+        delimited(char(delim), build_string, char(delim))
+            .map(|data| Delimited::delimitor(delim, data))
+            .parse(input)
+    }
+}
+
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum Text {
+    Texty(Vec<u8>),
+    Delim(Delimited),
+}
+
+impl Text {
+    fn texty(s: &[u8]) -> Self {
+        Self::Texty(s.to_owned())
+    }
+
+    fn mutate(&mut self, _rng: &mut dyn RngCore) {
         match self {
-            Self::DoubleQuote => 34,
-            Self::SingleQuote => 39,
+            Self::Texty(d) => mutate_text_data(_rng, d),
+            Self::Delim(d) => mutate_text_data(_rng, &mut d.data),
         }
     }
-    pub(crate) fn try_from(x: u8) -> Option<Self> {
-        if x == 34 {
-            return Some(Self::DoubleQuote);
+
+    fn unlex(self, v: &mut Vec<u8>) {
+        match self {
+            Text::Texty(a) => v.extend(a.into_iter()),
+            Text::Delim(delim) => delim.unlex(v),
         }
-        if x == 39 {
-            return Some(Self::SingleQuote);
-        }
-        return None;
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) enum Lex {
-    Text(Vec<u8>),
-    Byte(Vec<u8>),
-    Delimited(Delimiter, Vec<u8>),
+fn parse_texty<'a>(input: &'a [u8]) -> IResult<&'a [u8], Vec<Text>> {
+    let fold_ascii = |mut acc: Vec<Text>, dat: Text| {
+        match (acc.last_mut(), dat) {
+            // coalesce contiguous texty blocks
+            (Some(Text::Texty(ref mut a)), Text::Texty(b)) => a.extend(b.into_iter()),
+            (_, dat) => acc.push(dat),
+        }
+        acc
+    };
+
+    let parse_single_quote = alt((
+        parse_quoted_string('\'').map(Text::Delim),
+        // if coule not parse full delimited string, skip
+        tag(b"'").map(Text::texty),
+    ));
+
+    let parse_double_quote = alt((
+        parse_quoted_string('"').map(Text::Delim),
+        // if coule not parse full delimited string, skip
+        tag(b"\"").map(Text::texty),
+    ));
+
+    fold_many0(
+        alt((
+            verify(is_not(r#"'""#), |x: &[u8]| !x.is_empty()).map(Text::texty),
+            parse_single_quote,
+            parse_double_quote,
+        )),
+        Vec::new,
+        fold_ascii,
+    )
+    .parse(input)
 }
 
-fn is_texty(x: &u8) -> bool {
+#[derive(Debug, Eq, PartialEq, Clone)]
+pub enum Data {
+    Bytes(Vec<u8>),
+    Texty(Vec<Text>),
+}
+
+impl Data {
+    fn unlex(self, v: &mut Vec<u8>) {
+        match self {
+            Data::Texty(a) => {
+                for i in a.into_iter() {
+                    i.unlex(v);
+                }
+            }
+            Data::Bytes(a) => v.extend(a.into_iter()),
+        }
+    }
+}
+
+fn is_texty(x: u8) -> bool {
     match x {
         9 | 10 | 13 | 31..=125 => true,
         _ => false,
     }
 }
 
-fn is_texty_enough(data: &[u8]) -> bool {
-    let min_texty = 6;
-    data.iter().take(min_texty).all(is_texty)
+fn parse_texty_bytes<'a>(min_texty: usize) -> impl FnMut(&[u8]) -> IResult<&[u8], Vec<Text>> {
+    move |input: &[u8]| {
+        // returns success if more than min_texty contiguous "texty" bytes found
+        let texty = verify(take_while(is_texty), |x: &[u8]| x.len() >= min_texty);
+        texty.and_then(parse_texty).parse(input)
+    }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub(crate) struct Ascii(Vec<Lex>);
+fn parse_bytes<'a>(min_texty: usize) -> impl FnMut(&[u8]) -> IResult<&[u8], Vec<Data>> {
+    let fold_bytes = |mut acc: Vec<Data>, dat: Data| {
+        match (acc.last_mut(), dat) {
+            // coalesce contiguous byte blocks
+            (Some(Data::Bytes(ref mut a)), Data::Bytes(b)) => a.extend(b.into_iter()),
+            (_, dat) => acc.push(dat),
+        }
+        acc
+    };
+
+    move |input: &[u8]| {
+        // require texty bytes at the beginning of the string
+        let (remaining, (text, rest)) = parse_texty_bytes(min_texty)
+            .and(fold_many0(
+                alt((
+                    // if we had enough texty bytes, try parsing it
+                    parse_texty_bytes(min_texty).map(Data::Texty),
+                    // otherwise record it as a byte and pass through
+                    take(1usize).map(|x: &[u8]| Data::Bytes(x.to_owned())),
+                )),
+                Vec::new,
+                fold_bytes,
+            ))
+            .parse(input)?;
+
+        assert_eq!(
+            remaining, b"",
+            "If parsing succeeded, all input was consumed"
+        );
+
+        // combine the mandatory first text chunk with rest of the data
+        let mut ret = vec![Data::Texty(text.to_owned())];
+        ret.extend(rest.into_iter());
+        Ok((remaining, ret))
+    }
+}
+
+pub struct Ascii(Vec<Data>);
 
 impl Ascii {
-    // XXX: original string-lex function would identify delimiters (quotes or double quotes). Punt for now. Perhaps improve on radamsa's rudimentary algorithms
-    pub(crate) fn lex(data: &[u8]) -> Ascii {
-        let mut chunks = Vec::new();
-
-        let mut seen_data = Vec::new();
-        let mut i = 0;
-        while i < data.len() {
-            if is_texty_enough(&data[i..]) {
-                if seen_data.len() > 0 {
-                    // "flush" any raw bytes
-                    chunks.push(Lex::Byte(seen_data.clone()));
-                    seen_data.clear();
-                }
-                let mut seen_text = Vec::new();
-                while i < data.len() {
-                    if !is_texty(&data[i]) {
-                        break;
-                    }
-                    seen_text.push(data[i]);
-                    i += 1;
-                }
-                chunks.push(Lex::Text(seen_text))
-            } else {
-                seen_data.push(data[i]);
-                i += 1;
-            }
-        }
-        if seen_data.len() > 0 {
-            // "flush" any raw bytes
-            chunks.push(Lex::Byte(seen_data.clone()));
-        }
-
-        Self(chunks)
-    }
-
-    pub(crate) fn first_block_has_text(&self) -> bool {
-        match self.0.get(0) {
-            None | Some(Lex::Byte(_)) => false,
-            Some(_) => true,
+    pub(crate) fn parse(data: &[u8]) -> Result<Self, ()> {
+        if let Ok((_, ret)) = parse_bytes(6).parse(data) {
+            Ok(Self(ret))
+        } else {
+            Err(())
         }
     }
 
     pub(crate) fn mutate(&mut self, _rng: &mut dyn RngCore) {
         loop {
             // find a mutatable chunk, ignoring non-ascii data
-            match self.0.choose_mut(_rng).unwrap() {
-                Lex::Text(ref mut dat) | Lex::Delimited(_, ref mut dat) => {
-                    mutate_text_data(_rng, dat);
-                    break;
-                }
-                Lex::Byte(_) => {}
+            if let Data::Texty(ref mut dat) = self.0.choose_mut(_rng).unwrap() {
+                dat.choose_mut(_rng).unwrap().mutate(_rng);
+                break;
             }
         }
     }
 
     pub(crate) fn unlex(self) -> Vec<u8> {
         let mut ret = Vec::new();
-        for i in self.0 {
-            match i {
-                Lex::Byte(a) => ret.extend(a),
-                Lex::Text(a) => ret.extend(a),
-                Lex::Delimited(d, s) => {
-                    ret.push(d.as_u8());
-                    ret.extend(s);
-                    ret.push(d.as_u8());
-                }
-            }
+        for i in self.0.into_iter() {
+            i.unlex(&mut ret);
         }
         ret
     }
@@ -192,53 +285,37 @@ mod ascii_bad {
     use rand::{Rng, SeedableRng};
     use rand_chacha::ChaCha20Rng;
 
-    use super::{Ascii, Delimiter, Lex};
+    use crate::mutations::ascii::{Data, Delimited, Text};
+
+    use super::Ascii;
 
     #[test]
     fn basic() {
         // $ printf "AAAAAA\x00\x01\x02AAAAAA" | ./bin/ol -r ./rad/main.scm --mutations "ab" --patterns "od"
         let data = b"AAAAAA\x00\x01\x02AAAAAA".to_vec();
-        let cs = Ascii::lex(&data);
-        let a0 = Lex::Text(vec![0x41; 6]);
-        let a1 = Lex::Byte(vec![0x00, 0x01, 0x02]);
-        let a2 = Lex::Text(vec![0x41; 6]);
+        let cs = Ascii::parse(&data).unwrap();
         assert_eq!(cs.0.len(), 3);
-        assert_eq!(cs.0[0], a0);
-        assert_eq!(cs.0[1], a1);
-        assert_eq!(cs.0[2], a2);
+        assert_eq!(cs.0[0], Data::Texty(vec![Text::texty(b"AAAAAA")]));
+        assert_eq!(cs.0[1], Data::Bytes(vec![0x00, 0x01, 0x02]));
+        assert_eq!(cs.0[2], Data::Texty(vec![Text::texty(b"AAAAAA")]));
         let data_unlex: Vec<u8> = cs.unlex();
         assert_eq!(data, data_unlex);
     }
 
-    // expect this to fail since we haven't implemented delimiter checking yet
     #[test]
     fn delim() {
         // $ printf "AAAAAA\x00\x01\x02'AAAAAA'" | ./bin/ol -r ./rad/main.scm --mutations "ab" --patterns "od"
         let data = b"AAAAAA\x00\x01\x02'AAAAAA'".to_vec();
-        let cs = Ascii::lex(&data);
-        let a0 = Lex::Text(vec![0x41; 6]);
-        let a1 = Lex::Byte(vec![0x00, 0x01, 0x02]);
-        let a2 = Lex::Delimited(Delimiter::SingleQuote, vec![0x41; 6]);
+        let cs = Ascii::parse(&data).unwrap();
         assert_eq!(cs.0.len(), 3);
-        assert_eq!(cs.0[0], a0);
-        assert_eq!(cs.0[1], a1);
-        assert_ne!(cs.0[2], a2); // expect to fail
-        let data_unlex = cs.unlex();
+        assert_eq!(cs.0[0], Data::Texty(vec![Text::texty(b"AAAAAA")]));
+        assert_eq!(cs.0[1], Data::Bytes(vec![0x00, 0x01, 0x02]));
+        assert_eq!(
+            cs.0[2],
+            Data::Texty(vec![Text::Delim(Delimited::delimitor('\'', b"AAAAAA"))])
+        );
+        let data_unlex: Vec<u8> = cs.unlex();
         assert_eq!(data, data_unlex);
-    }
-
-    #[test]
-    fn mutate_smoke_test() {
-        let mut rng = ChaCha20Rng::seed_from_u64(1683310580);
-        for _ in 0..1000 {
-            let a0 = Lex::Text(vec![0x41; 6]);
-            let a1 = Lex::Byte(vec![0x00, 0x01, 0x02]);
-            let a2 = Lex::Delimited(Delimiter::SingleQuote, vec![0x41; 6]);
-            let mut ascii = Ascii(vec![a0, a1, a2]);
-            for _ in 0..10 {
-                ascii.mutate(&mut rng);
-            }
-        }
     }
 
     #[test]
@@ -250,9 +327,17 @@ mod ascii_bad {
             for i in 0..1000 {
                 data[i] = rng.gen();
             }
-            let cs = Ascii::lex(&data);
-            let roundtrip = cs.unlex();
-            assert_eq!(&data, &roundtrip);
+            if let Ok(cs) = Ascii::parse(&data) {
+                assert_eq!(&data, &cs.unlex());
+            }
         }
+    }
+
+    #[test]
+    fn first_chunk_byte() {
+        // if the first chunk is not text, Ascii should fail to parse
+        let data = b"\x01AAAAAAAAAAAAAAAA";
+        let res = Ascii::parse(data);
+        assert!(res.is_err());
     }
 }

--- a/src/mutations/ascii.rs
+++ b/src/mutations/ascii.rs
@@ -76,9 +76,9 @@ fn mutate_text_data(_rng: &mut dyn RngCore, data: &mut Vec<u8>) {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub struct Delimited {
-    pub delimitor: u8,
-    pub data: Vec<u8>,
+struct Delimited {
+    delimitor: u8,
+    data: Vec<u8>,
 }
 
 impl Delimited {
@@ -152,7 +152,7 @@ mod quoted_string {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub enum Text {
+enum Text {
     Texty(Vec<u8>),
     Delim(Delimited),
 }
@@ -212,7 +212,7 @@ fn parse_texty<'a>(input: &'a [u8]) -> IResult<&'a [u8], Vec<Text>> {
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]
-pub enum Data {
+enum Data {
     Bytes(Vec<u8>),
     Texty(Vec<Text>),
 }
@@ -232,7 +232,7 @@ impl Data {
 
 fn is_texty(x: u8) -> bool {
     match x {
-        9 | 10 | 13 | 31..=125 => true,
+        9 | 10 | 13 | 32..=126 => true,
         _ => false,
     }
 }
@@ -282,6 +282,7 @@ fn parse_bytes<'a>(min_texty: usize) -> impl FnMut(&[u8]) -> IResult<&[u8], Vec<
     }
 }
 
+#[derive(Debug)]
 pub struct Ascii(Vec<Data>);
 
 impl Ascii {


### PR DESCRIPTION
Adds nom dependency to Cargo.toml

Reworks existing homebrew ascii lexing logic to leverage nom's parser-combinators

Adds support for quote-delimited strings, ignoring escaped quotes

Example:

```
$ echo foo = "AAAA" | cargo run -- --mutators ab --patterns od
foo = "A\r\n%p%d&#000;$(xcalc)+inf\u0000&#000;NaN\u0000\x0a!xcalc%d$!!\00NaNAAA"
```